### PR TITLE
Update for new Google maps.app.goo.gl URL

### DIFF
--- a/routes/map.js
+++ b/routes/map.js
@@ -32,7 +32,7 @@ const modifyUrl = url => {
 }
 
 router.get('/:shortId', function (req, res) {
-  const uri = 'https://goo.gl/maps/' + req.params.shortId
+  const uri = 'https://maps.app.goo.gl/' + req.params.shortId
   request(
     {
       uri: uri,


### PR DESCRIPTION
Seems that Google has changed the share domain from `https://goo.gl/maps/` to `https://maps.app.goo.gl/`.

This change makes the script work again!